### PR TITLE
Add Curse of Deceit enchantment

### DIFF
--- a/src/main/java/com/astrazoey/indexed/Indexed.java
+++ b/src/main/java/com/astrazoey/indexed/Indexed.java
@@ -115,6 +115,7 @@ public class Indexed implements ModInitializer {
     public static ComponentType<EnchantmentValueEffect> REDUCE_REPAIR_COST = registerEnchantment("reduce_repair_cost", builder -> builder.codec(EnchantmentValueEffect.CODEC));
     public static ComponentType<Unit> HIDE_ARMOR = registerEnchantment("hide_armor", builder -> builder.codec(Unit.CODEC));
     public static ComponentType<Unit> HIDE_ENCHANTMENTS = registerEnchantment("hide_enchantments", builder -> builder.codec(Unit.CODEC));
+    public static ComponentType<Unit> HIDE_DURABILITY = registerEnchantment("hide_durability", builder -> builder.codec(Unit.CODEC));
 
     //Blocks
     public static final Block CRYSTAL_GLOBE = new CrystalGlobeBlock(Block.Settings.create().

--- a/src/main/java/com/astrazoey/indexed/mixins/DeceitCurseClientMixin.java
+++ b/src/main/java/com/astrazoey/indexed/mixins/DeceitCurseClientMixin.java
@@ -1,0 +1,29 @@
+package com.astrazoey.indexed.mixins;
+
+import com.astrazoey.indexed.Indexed;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(DrawContext.class)
+public class DeceitCurseClientMixin {
+
+    @Redirect(
+        method = "drawItemBar",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/ItemStack;isItemBarVisible()Z"
+        )
+    )
+    private boolean hideDurabilityBarForCurse(ItemStack stack) {
+        // If the item has the curse, return false to hide the durability bar
+        if (EnchantmentHelper.hasAnyEnchantmentsWith(stack, Indexed.HIDE_DURABILITY)) {
+            return false;
+        }
+        // Otherwise, use the original behavior
+        return stack.isItemBarVisible();
+    }
+}

--- a/src/main/java/com/astrazoey/indexed/mixins/DeceitCurseMixin.java
+++ b/src/main/java/com/astrazoey/indexed/mixins/DeceitCurseMixin.java
@@ -1,0 +1,31 @@
+package com.astrazoey.indexed.mixins;
+
+import com.astrazoey.indexed.Indexed;
+import net.minecraft.component.ComponentType;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.TooltipDisplayComponent;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = ItemStack.class, priority = 1001)
+public abstract class DeceitCurseMixin {
+
+    @Redirect(
+        method = "appendTooltip",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/component/type/TooltipDisplayComponent;shouldDisplay(Lnet/minecraft/component/ComponentType;)Z"
+        )
+    )
+    private boolean hideDurabilityForCurse(TooltipDisplayComponent instance, ComponentType<?> type) {
+        // If checking for DAMAGE component and item has curse, return false to hide it
+        if (type == DataComponentTypes.DAMAGE && EnchantmentHelper.hasAnyEnchantmentsWith((ItemStack) (Object) this, Indexed.HIDE_DURABILITY)) {
+            return false;
+        }
+        // Otherwise, use original behavior
+        return instance.shouldDisplay(type);
+    }
+}

--- a/src/main/resources/assets/indexed/lang/en_us.json
+++ b/src/main/resources/assets/indexed/lang/en_us.json
@@ -20,6 +20,8 @@
   "enchantment.indexed.mystery_curse": "Curse of Mystery",
   "enchantment.indexed.mystery_curse.desc": "It is a mystery",
   "enchantment.indexed.mystery_tooltip": "Curse of Mystery",
+  "enchantment.indexed.curse_of_deceit": "Curse of Deceit",
+  "enchantment.indexed.curse_of_deceit.desc": "Item lies about its durability",
   "advancements.indexed.story.root.title": "Indexed",
   "advancements.indexed.story.root.description": "Enchanting done differently",
   "advancements.indexed.story.overcharge.title": "Overcharged!",

--- a/src/main/resources/data/indexed/enchantment/curse_of_deceit.json
+++ b/src/main/resources/data/indexed/enchantment/curse_of_deceit.json
@@ -1,0 +1,23 @@
+{
+  "anvil_cost": 4,
+  "description": {
+    "translate": "enchantment.indexed.curse_of_deceit"
+  },
+  "effects": {
+    "indexed:hide_durability": {}
+  },
+  "max_cost": {
+    "base": 50,
+    "per_level_above_first": 0
+  },
+  "max_level": 1,
+  "min_cost": {
+    "base": 25,
+    "per_level_above_first": 0
+  },
+  "slots": [
+    "any"
+  ],
+  "supported_items": "#minecraft:enchantable/durability",
+  "weight": 2
+}

--- a/src/main/resources/data/minecraft/tags/enchantment/curse.json
+++ b/src/main/resources/data/minecraft/tags/enchantment/curse.json
@@ -1,7 +1,8 @@
 {
   "values": [
     "indexed:mystery_curse",
-    "indexed:hidden_curse"
+    "indexed:hidden_curse",
+    "indexed:curse_of_deceit"
   ],
   "replace": false
 }

--- a/src/main/resources/indexed.mixins.json
+++ b/src/main/resources/indexed.mixins.json
@@ -10,6 +10,7 @@
     "DamageLivingEntityMixin",
     "ColorSpecialMixin",
     "DebuffResistanceMixin",
+    "DeceitCurseMixin",
     "EnchantBookFactoryMixin",
     "EnchantmentHelperMixin",
     "EnchantmentMixin",
@@ -36,6 +37,7 @@
   "client": [
     "AnvilScreenMixin",
     "ArmorFeatureRendererMixin",
+    "DeceitCurseClientMixin",
     "ElytraFeatureRendererMixin",
     "ItemRendererMixin"
   ],


### PR DESCRIPTION
Implements a new curse enchantment that hides durability information from items:
- Hides the durability bar in inventory
- Hides the durability tooltip text
- Works on any item with durability

The enchantment uses two mixins:
- DeceitCurseMixin: Hides tooltip durability information
- DeceitCurseClientMixin: Hides the visual durability bar