### PR TITLE
Add config option to disable overcharging

### DIFF
--- a/src/main/java/com/astrazoey/indexed/ConfigMain.java
+++ b/src/main/java/com/astrazoey/indexed/ConfigMain.java
@@ -34,6 +34,9 @@ public class ConfigMain {
     private static final int linearXpAmountDefault = 30;
     public static int linearXpAmount = linearXpAmountDefault;
 
+    private static final String ENABLE_OVERCHARGE = "enable-overenchanting";
+    public static boolean enableOvercharge = true;
+
     public static void save() {
         Properties props = new Properties();
         read(props);
@@ -101,6 +104,7 @@ public class ConfigMain {
         props.setProperty(ENABLE_VILLAGER_NERFS_KEY, String.valueOf(enableVillagerNerfs));
         props.setProperty(ENABLE_LINEAR_XP, String.valueOf(enableLinearXp));
         props.setProperty(LINEAR_XP_AMOUNT, String.valueOf(linearXpAmount));
+        props.setProperty(ENABLE_OVERCHARGE, String.valueOf(enableOvercharge));
     }
 
     public static void assign(Properties props) {
@@ -110,6 +114,7 @@ public class ConfigMain {
         enableVillagerNerfs = defaultBoolean(props.getProperty(ENABLE_VILLAGER_NERFS_KEY), true);
         enableLinearXp = defaultBoolean(props.getProperty(ENABLE_LINEAR_XP), true);
         linearXpAmount = defaultInt(props.getProperty(LINEAR_XP_AMOUNT), linearXpAmountDefault);
+        enableOvercharge = defaultBoolean(props.getProperty(ENABLE_OVERCHARGE), true);
     }
 
     private static boolean defaultBoolean(String bool, boolean defaultOption) {

--- a/src/main/java/com/astrazoey/indexed/mixins/EnchantmentHelperMixin.java
+++ b/src/main/java/com/astrazoey/indexed/mixins/EnchantmentHelperMixin.java
@@ -1,9 +1,11 @@
 package com.astrazoey.indexed.mixins;
 
+import com.astrazoey.indexed.ConfigMain;
 import com.astrazoey.indexed.Indexed;
 import com.astrazoey.indexed.MaxEnchantingSlots;
 import com.astrazoey.indexed.registry.IndexedItems;
 import com.google.common.collect.Lists;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.advancement.criterion.EnchantedItemCriterion;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -19,6 +21,7 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.*;
@@ -26,6 +29,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static java.lang.Math.min;
@@ -67,6 +71,25 @@ public class EnchantmentHelperMixin {
         }
     }
 
+    @ModifyArg(method =  "generateEnchantments", at = @At(value = "INVOKE", target = "Ljava/util/Optional;ifPresent(Ljava/util/function/Consumer;)V", ordinal = 1))
+    private static @NotNull Consumer<EnchantmentLevelEntry> returnEarlyIfOverBudget(Consumer<EnchantmentLevelEntry> action, @Local(ordinal = 0) List<EnchantmentLevelEntry> list, @Local(ordinal = 0) ItemStack stack) {
+        // if overcharge is enabled, return default value. Else, run custom function
+        return ConfigMain.enableOvercharge ? action : (enchant) -> {
+            // get the list of enchants in itemstack form, so that I can use MaxEnchantingSlots functions
+            ItemStack stackCopy = stack.copy();
+            for (EnchantmentLevelEntry e : list) {
+                stackCopy.addEnchantment(e.enchantment(), e.level());
+            }
+
+            int maxSlots = MaxEnchantingSlots.getEnchantType(stackCopy).maxEnchantingSlots;
+            int usedSlots = MaxEnchantingSlots.getCurrent(stackCopy);
+
+            //only add the enchantment if it fits in the remaining slots
+            if (usedSlots + enchant.level() <= maxSlots) {
+                list.add(enchant);
+            }
+        };
+    }
 
 
     @Inject(method = "getPossibleEntries", at = @At(value = "HEAD"), cancellable = true)
@@ -161,11 +184,15 @@ class TakeEnchantment {
     //Take Enchanted Status Effect Into Account
     @Redirect(method="method_17410", at = @At(value="INVOKE", target = "Lnet/minecraft/item/ItemStack;addEnchantment(Lnet/minecraft/registry/entry/RegistryEntry;I)V"))
     public void enchantedStatusEffect(ItemStack instance, RegistryEntry<Enchantment> enchantment, int level) {
+        int newEnchantmentLevel;
         if(effectLevel != null) {
-            int newEnchantmentLevel = min(level+effectLevel.get(), enchantment.value().getMaxLevel());
-            instance.addEnchantment(enchantment, newEnchantmentLevel);
+            newEnchantmentLevel = min(level+effectLevel.get(), enchantment.value().getMaxLevel());
         } else {
-            instance.addEnchantment(enchantment, level);
+            newEnchantmentLevel = level;
+        }
+        
+        if (ConfigMain.enableOvercharge || MaxEnchantingSlots.getCurrent(instance) + newEnchantmentLevel <= MaxEnchantingSlots.getEnchantType(instance).maxEnchantingSlots) {
+            instance.addEnchantment(enchantment, newEnchantmentLevel);
         }
     }
 


### PR DESCRIPTION
Adds a config option, 'enable-overcharging' (true by default), and makes the following changes:

- Mixins the `generateEnchantments` method in the `EnchantmentHelper` class, which is called for generating enchantments in loot generation as well as the enchantment table. When overcharging is disabled, it will not add enchantments that would exceed the item's max slots.
- Edits the `enchantedStatusEffect` redirect mixin, also in `EnchantmentHelper`, to avoid adding enchantments that would exceed the item's max slots when overcharging is disabled.